### PR TITLE
upgrade date-fns and add date reference prop to time picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-time-picker-date-fns",
-  "version": "3.2.8",
+  "version": "3.3.0",
   "description": "React TimePicker using date-fns",
   "keywords": [
     "react",
@@ -25,7 +25,6 @@
   "bugs": {
     "url": "http://github.com/frostiebot/time-picker/issues"
   },
-  "licenses": "MIT",
   "config": {
     "port": 8011
   },
@@ -62,7 +61,7 @@
   "dependencies": {
     "babel-runtime": "6.x",
     "classnames": "2.x",
-    "date-fns": "^2.0.0-alpha.7",
+    "date-fns": "^2.17.0",
     "prop-types": "^15.5.8",
     "rc-trigger": "^2.2.0"
   },

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -162,9 +162,9 @@ class Combobox extends Component {
       return null;
     }
 
-    const AMPMOptions = ['am', 'pm'] // If format has A char, then we should uppercase AM/PM
-                          .map(c => format.match(/\sA/) ? c.toUpperCase() : c)
-                          .map(c => ({ value: c }));
+    const AMPMOptions = ['am', 'pm'] // If format has 'a' char, then we should uppercase AM/PM
+      .map(c => format.match(/\sa/) ? c.toUpperCase() : c)
+      .map(c => ({ value: c }));
 
     const selected = this.isAM() ? 0 : 1;
 

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -23,7 +23,7 @@ class Header extends Component {
     disabledDate: PropTypes.func,
     placeholder: PropTypes.string,
     clearText: PropTypes.string,
-    value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    value: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
     hourOptions: PropTypes.array,
     minuteOptions: PropTypes.array,
     secondOptions: PropTypes.array,
@@ -34,17 +34,18 @@ class Header extends Component {
     onClear: PropTypes.func,
     onEsc: PropTypes.func,
     allowEmpty: PropTypes.bool,
-    defaultOpenValue: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    defaultOpenValue: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
     currentSelectPanel: PropTypes.string,
     focusOnOpen: PropTypes.bool,
     onKeyDown: PropTypes.func,
+    referenceDate: PropTypes.instanceOf(Date),
   };
 
   constructor(props) {
     super(props);
-    const { value, format } = props;
+    const { value, format, referenceDate } = props;
     this.state = {
-      str: value && formatTime(value, format) || '',
+      str: value && formatTime(value, format, referenceDate) || '',
       invalid: false,
     };
   }
@@ -61,9 +62,9 @@ class Header extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { value, format } = nextProps;
+    const { value, format, referenceDate } = nextProps;
     this.setState({
-      str: value && formatTime(value, format) || '',
+      str: value && formatTime(value, format, referenceDate) || '',
       invalid: false,
     });
   }
@@ -77,11 +78,12 @@ class Header extends Component {
       format, hourOptions, minuteOptions, secondOptions,
       disabledHours, disabledMinutes,
       disabledSeconds, onChange, allowEmpty,
+      referenceDate,
     } = this.props;
 
     if (str) {
       const originalValue = this.props.value;
-      const parsed = parseTime(str, format);
+      const parsed = parseTime(str, format, referenceDate);
 
 
       if (!isValidTime(parsed)) {

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -8,7 +8,7 @@ import { parseTime, getHours, getMinutes } from './date-utils';
 import Header from './Header';
 import Combobox from './Combobox';
 
-function noop() {}
+function noop() { }
 
 function generateOptions(length, disabledOptions, hideDisabledOptions, step = 1) {
   const arr = [];
@@ -25,8 +25,8 @@ class Panel extends Component {
     clearText: PropTypes.string,
     prefixCls: PropTypes.string,
     className: PropTypes.string,
-    defaultOpenValue: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-    value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    defaultOpenValue: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
+    value: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
     placeholder: PropTypes.string,
     format: PropTypes.string,
     disabledHours: PropTypes.func,
@@ -47,6 +47,7 @@ class Panel extends Component {
     addon: PropTypes.func,
     focusOnOpen: PropTypes.bool,
     onKeyDown: PropTypes.func,
+    referenceDate: PropTypes.instanceOf(Date),
   };
 
   static defaultProps = {
@@ -65,7 +66,7 @@ class Panel extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: parseTime(props.value),
+      value: parseTime(props.value, undefined, props.referenceDate),
       selectionRange: [],
     };
   }
@@ -112,7 +113,7 @@ class Panel extends Component {
       value
         ? getMinutes(value)
         : null
-      );
+    );
 
     const hourOptions = generateOptions(
       24, disabledHourOptions, hideDisabledOptions, hourStep

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -8,7 +8,7 @@ import { formatTime } from './date-utils';
 import Panel from './Panel';
 import placements from './placements';
 
-function noop() {}
+function noop() { }
 
 function refFn(field, component) {
   this[field] = component;
@@ -18,11 +18,11 @@ export default class Picker extends Component {
   static propTypes = {
     prefixCls: PropTypes.string,
     clearText: PropTypes.string,
-    value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-    defaultOpenValue: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    value: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
+    defaultOpenValue: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
     disabled: PropTypes.bool,
     allowEmpty: PropTypes.bool,
-    defaultValue: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    defaultValue: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
     open: PropTypes.bool,
     defaultOpen: PropTypes.bool,
     align: PropTypes.object,
@@ -56,6 +56,7 @@ export default class Picker extends Component {
     focusOnOpen: PropTypes.bool,
     onKeyDown: PropTypes.func,
     autoFocus: PropTypes.bool,
+    referenceDate: PropTypes.instanceOf(Date),
   };
 
   static defaultProps = {
@@ -86,6 +87,7 @@ export default class Picker extends Component {
     use12Hours: false,
     focusOnOpen: false,
     onKeyDown: noop,
+    referenceDate: new Date,
   };
 
   constructor(props) {
@@ -150,8 +152,9 @@ export default class Picker extends Component {
         showMinute ? 'mm' : '',
         showSecond ? 'ss' : '',
       ].filter(item => !!item).join(':'));
-
-      return fmtString.concat(' a');
+      // aaaaa format outputs 'p' or 'a', but not 'am' or 'pm'
+      // So we add an 'm' to the end to achieve am/pm
+      return fmtString.concat(" aaaaa'm'");
     }
 
     return [
@@ -167,6 +170,7 @@ export default class Picker extends Component {
       disabledMinutes, disabledSeconds, hideDisabledOptions,
       allowEmpty, showHour, showMinute, showSecond, defaultOpenValue, clearText,
       addon, use12Hours, focusOnOpen, onKeyDown, hourStep, minuteStep, secondStep,
+      referenceDate,
     } = this.props;
     return (
       <Panel
@@ -195,6 +199,7 @@ export default class Picker extends Component {
         addon={addon}
         focusOnOpen={focusOnOpen}
         onKeyDown={onKeyDown}
+        referenceDate={referenceDate}
       />
     );
   }
@@ -249,7 +254,7 @@ export default class Picker extends Component {
     const {
       prefixCls, placeholder, placement, align,
       disabled, transitionName, style, className, getPopupContainer, name, autoComplete,
-      onFocus, onBlur, autoFocus,
+      onFocus, onBlur, autoFocus, referenceDate,
     } = this.props;
     const { open, value } = this.state;
     const popupClassName = this.getPopupClassName();
@@ -278,14 +283,14 @@ export default class Picker extends Component {
             name={name}
             onKeyDown={this.onKeyDown}
             disabled={disabled}
-            value={value && formatTime(value, this.getFormat()) || ''}
+            value={value && formatTime(value, this.getFormat(), referenceDate) || ''}
             autoComplete={autoComplete}
             onFocus={onFocus}
             onBlur={onBlur}
             autoFocus={autoFocus}
             onChange={noop}
           />
-          <span className={`${prefixCls}-icon`}/>
+          <span className={`${prefixCls}-icon`} />
         </span>
       </Trigger>
     );

--- a/src/date-utils.js
+++ b/src/date-utils.js
@@ -1,7 +1,7 @@
 import {
   parse as parseDate,
   format as formatDate,
-  toDate,
+  parseISO,
   isValid,
   getHours,
   setHours,
@@ -14,7 +14,16 @@ import {
   isSameSecond,
 } from 'date-fns/esm';
 
-export const parseTime = (value, format = null) => {
+/**
+ * Returns x raised to the n-th power.
+ *
+ * @param {string} value a string representing time
+ * @param {format} string date-fns format string
+ * @param {Date} Date assign a date to this value
+ * @return {Date} returns a date based on the value string
+ */
+
+export const parseTime = (value, format = null, referenceDate = new Date()) => {
   if (value === null) {
     return value;
   }
@@ -22,19 +31,20 @@ export const parseTime = (value, format = null) => {
     return value;
   }
   if (format === null) {
-    return toDate(value);
+    return parseISO(value);
   }
 
-  const parsed = parseDate(value, format, new Date);
+  const parsed = parseDate(value, format, referenceDate);
 
-  if (!isValid(parsed) || !value.startsWith(formatDate(parsed, format))) {
+  if (!isValid(parsed) || (format && !value.startsWith(formatDate(parsed, format)))) {
     return new Date('');
   }
 
   return parsed;
 };
 
-export const formatTime = (value, format) => formatDate(parseTime(value, format), format);
+export const formatTime = (value, format, referenceDate) =>
+  formatDate(parseTime(value, format, referenceDate), format);
 
 export const isValidTime = value => isValid(value);
 

--- a/tests/Select.spec.jsx
+++ b/tests/Select.spec.jsx
@@ -454,7 +454,7 @@ describe('Select', () => {
         use12Hours: true,
         defaultValue: parseTime('00:00:00', 'HH:mm:ss'),  // moment().hour(0).minute(0).second(0),
         showSecond: false,
-        format: undefined,
+        format: null,
       });
       expect(picker.state.open).not.to.be.ok();
       const input = TestUtils.scryRenderedDOMComponentsWithClass(picker,
@@ -525,7 +525,7 @@ describe('Select', () => {
         use12Hours: true,
         defaultValue: parseTime('00:00:00', 'HH:mm:ss'),  // moment().hour(0).minute(0).second(0),
         showSecond: false,
-        format: 'h:mm A',
+        format: 'h:mm a',
       });
       expect(picker.state.open).not.to.be.ok();
       const input = TestUtils.scryRenderedDOMComponentsWithClass(picker,

--- a/tests/TimePicker.spec.jsx
+++ b/tests/TimePicker.spec.jsx
@@ -49,7 +49,7 @@ describe('TimePicker', () => {
       <TimePicker
         format={format}
         showSecond={showSecond}
-        defaultValue={parseTime('01:24:03', format)}
+        defaultValue={parseTime('01:24', format)}
         {...props}
       />, container);
   }
@@ -64,7 +64,7 @@ describe('TimePicker', () => {
         format={format}
         showSecond={showSecond}
         showMinute={showMinute}
-        defaultValue={parseTime('01:24:03', format)}
+        defaultValue={parseTime('01', format)}
         {...props}
       />, container);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2248,9 +2248,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^2.0.0-alpha.7:
-  version "2.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-alpha.7.tgz#245ad16f95764eababfb2c0a41fd5d033c20e57a"
+date-fns@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
+  integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
 
 date-now@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
- Upgrade date-fns from alpha 2.0.0 to 2.17.0 (the most recent version as of this PR)
- Add a referenceDate prop to time picker which allows us to choose the date we're selecting time for.  This really only matters when it's Spring Forward/Back and we can't select the hour that doesn't exist (In this case, March 14th 2am doesn't exist).  If someone needs to set a time for some other day, while the current day is March 14th, they can pass in a reference date.